### PR TITLE
adapt recent compiler changes

### DIFF
--- a/lib/c64.mbt
+++ b/lib/c64.mbt
@@ -224,7 +224,8 @@ pub fn reset(self : C64) -> Unit! {
     self.sampleRate = 44100
   }
   self.cpuFrequency = CPUClock(self.videoStandard)
-  self.sampleClockRatio = (self.cpuFrequency << 4) / self.sampleRate //shifting (multiplication) enhances SampleClockRatio precision
+  self.sampleClockRatio = (self.cpuFrequency.to_int?().unwrap() << 4) /
+    self.sampleRate //shifting (multiplication) enhances SampleClockRatio precision
   //
   self.vic.rasterCompare = ScanLines(self.videoStandard).to_int!() // HINT: should be inferred
   self.vic.rasterRowCycles = ScanLineCycles(self.videoStandard).to_int!() // HINT: should be inferred

--- a/lib/c64_video.mbt
+++ b/lib/c64_video.mbt
@@ -51,16 +51,6 @@ fn CPUClock::op_get(self : CPUClock, value : VideoStandard) -> Int! {
 }
 
 ///|
-fn CPUClock::op_shl(self : CPUClock, bits : Int) -> Int {
-  try {
-    self.to_int!() << bits
-  } catch {
-    // Do nothing
-    _ => ...
-  }
-}
-
-///|
 test "CPUClock::None" {
   let value = CPUClock(Unknown)
   assert_eq!(value, Unknown)
@@ -92,14 +82,14 @@ test "error CPUClock::Both" {
 test "CPUClock::NTSC shift left" {
   let value = CPUClock(NTSC)
   assert_eq!(value, NTSC)
-  inspect!(value << 4, content="16363632")
+  inspect!(value.to_int?().unwrap() << 4, content="16363632")
 }
 
 ///|
 test "CPUClock::PAL shift left" {
   let value = CPUClock(PAL)
   assert_eq!(value, PAL)
-  inspect!(value << 4, content="15763968")
+  inspect!(value.to_int?().unwrap() << 4, content="15763968")
 }
 
 ///|

--- a/lib/cpu/cpu.mbt
+++ b/lib/cpu/cpu.mbt
@@ -818,13 +818,13 @@ fn opAND(self : CPU, addr : UInt16, mode : Mode) -> Unit {
 fn opASL(self : CPU, addr : UInt16, mode : Mode) -> Unit {
   match mode {
     Accumulator => {
-      self.flags.setC((self.registers[A] & N.bits()) != 0)
+      self.flags.setC((self.registers[A] & N) != 0)
       self.registers[A] = self.registers[A]._ << 1 |> u8 // overflow
       self.flags.setZN(self.registers[A])
     }
     _ => {
       let mut value = self.read(addr)
-      self.flags.setC((value & N.bits()) != 0)
+      self.flags.setC((value & N) != 0)
       value = value._ << 1 |> u8 // overflow
       self.write(addr, value)
       self.flags.setZN(value)
@@ -860,7 +860,7 @@ fn opBEQ(self : CPU, addr : UInt16, mode : Mode) -> Unit {
 ///|
 fn opBIT(self : CPU, addr : UInt16, mode : Mode) -> Unit {
   let value = self.read(addr)
-  self.flags.setV((value & V.bits()) != 0)
+  self.flags.setV((value & V) != 0)
   self.flags.setZ((value & self.registers[A]) == 0)
   self.flags.setN(value.bit(7))
 }
@@ -1098,13 +1098,13 @@ fn opLDY(self : CPU, addr : UInt16, mode : Mode) -> Unit {
 fn opLSR(self : CPU, addr : UInt16, mode : Mode) -> Unit {
   match mode {
     Accumulator => {
-      self.flags.setC((self.registers[A] & C.bits()) != 0)
+      self.flags.setC((self.registers[A] & C) != 0)
       self.registers[A] = self.registers[A]._ >> 1 |> u8 // underflow
       self.flags.setZN(self.registers[A])
     }
     _ => {
       let mut value = self.read(addr)
-      self.flags.setC((value & C.bits()) != 0)
+      self.flags.setC((value & C) != 0)
       value = value._ >> 1 |> u8 // underflow
       self.write(addr, value)
       self.flags.setZN(value)
@@ -1138,7 +1138,7 @@ fn opPHA(self : CPU, addr : UInt16, mode : Mode) -> Unit {
 ///
 /// The `PHP` instruction affects no registers or flags in the micropro­cessor.
 fn opPHP(self : CPU, addr : UInt16, mode : Mode) -> Unit {
-  self.push(self.flags.get() | B.bits() | U.bits())
+  self.push(self.flags.get() | B | U)
 }
 
 // PLA - Pull accumulator
@@ -1156,8 +1156,8 @@ fn opPLA(self : CPU, addr : UInt16, mode : Mode) -> Unit {
 /// The `PLP` instruction affects no registers in the processor other than the status register.
 /// This instruction could affect all flags in the status register.
 fn opPLP(self : CPU, addr : UInt16, mode : Mode) -> Unit {
-  // self.flags.set(self.pop()&(0xCF)|(U.bits())|(B.bits())) // pull() & 0xEF | 0x20
-  self.flags.set((self.pop() & 0xEF) | U.bits()) // nestest: pull() & 0xEF | 0x20
+  // self.flags.set(self.pop()&(0xCF)|(U)|(B)) // pull() & 0xEF | 0x20
+  self.flags.set((self.pop() & 0xEF) | U) // nestest: pull() & 0xEF | 0x20
 }
 
 // ROL - Rotate left
@@ -1166,13 +1166,13 @@ fn opROL(self : CPU, addr : UInt16, mode : Mode) -> Unit {
   let c = self.flags[C].to_int()
   match mode {
     Accumulator => {
-      self.flags.setC((self.registers[A] & N.bits()) != 0)
+      self.flags.setC((self.registers[A] & N) != 0)
       self.registers[A] = (self.registers[A]._ << 1 |> u8) | c // overflow
       self.flags.setZN(self.registers[A])
     }
     _ => {
       let mut value = self.read(addr)
-      self.flags.setC((value & N.bits()) != 0)
+      self.flags.setC((value & N) != 0)
       value = (value._ << 1 |> u8) | c // overflow
       self.write(addr, value)
       self.flags.setZN(value)
@@ -1186,13 +1186,13 @@ fn opROR(self : CPU, addr : UInt16, mode : Mode) -> Unit {
   let c = self.flags[C].to_int()
   match mode {
     Accumulator => {
-      self.flags.setC((self.registers[A] & C.bits()) != 0)
+      self.flags.setC((self.registers[A] & C) != 0)
       self.registers[A] = (self.registers[A]._ >> 1 |> u8) | (c << 7) // underflow
       self.flags.setZN(self.registers[A])
     }
     _ => {
       let mut value = self.read(addr)
-      self.flags.setC((value & C.bits()) != 0)
+      self.flags.setC((value & C) != 0)
       value = (value._ >> 1 |> u8) | (c << 7) // underflow
       self.write(addr, value)
       self.flags.setZN(value)
@@ -1210,8 +1210,8 @@ fn opROR(self : CPU, addr : UInt16, mode : Mode) -> Unit {
 /// It affects no other registers in the microprocessor.
 fn opRTI(self : CPU, addr : UInt16, mode : Mode) -> Unit {
   println("*** RTI")
-  // self.flags.set(self.pop()&(0xCF)|(U.bits())|(B.bits())) // pull() & 0xEF | 0x20
-  // self.flags.set((self.pop() & 0xEF) | U.bits()) // nestest: pull() & 0xEF | 0x20
+  // self.flags.set(self.pop()&(0xCF)|(U)|(B)) // pull() & 0xEF | 0x20
+  // self.flags.set((self.pop() & 0xEF) | U) // nestest: pull() & 0xEF | 0x20
   self.flags.set(self.pop())
   self.pc = self.pop16()
   // self.opSEI(addr, mode)

--- a/lib/cpu/cpu.mbti
+++ b/lib/cpu/cpu.mbti
@@ -1,6 +1,69 @@
-package trancee/wasmSID/lib/cpu
+package "trancee/wasmSID/lib/cpu"
 
 // Values
+const B : Int = 0b00010000
+
+const C : Int = 0b00000001
+
+const D : Int = 0b00001000
+
+const I : Int = 0b00000100
+
+const N : Int = 0b10000000
+
+const U : Int = 0b00100000
+
+const V : Int = 0b01000000
+
+const Z : Int = 0b00000010
+
+fn bit(UInt8, UInt8) -> Bool
+
+fn clear_flags(CPU) -> Unit
+
+fn clear_registers(CPU) -> Unit
+
+fn debug(CPU, Bool) -> Bool
+
+fn get_registers(CPU) -> Registers
+
+fn interrupts(CPU) -> Bool
+
+fn irq(CPU, pc? : Int) -> Unit
+
+fn load(CPU, Int, FixedArray[Int], length~ : Int = .., has_load_address~ : Bool = ..) -> Int
+
+fn nmi(CPU, pc? : Int) -> Unit
+
+fn push(CPU, UInt8, dummy~ : Bool = ..) -> Unit
+
+fn push16(CPU, UInt16) -> Unit
+
+fn read(CPU, UInt16, dummy~ : Bool = ..) -> UInt8
+
+fn register(CPU, Register, Int) -> Unit
+
+fn setIRQ(CPU, UInt16) -> Unit
+
+fn setNMI(CPU, UInt16) -> Unit
+
+fn set_interrupt(Flags) -> Unit
+
+fn set_irq(CPU, state~ : Bool = ..) -> Unit
+
+fn set_nmi(CPU, state~ : Bool = ..) -> Unit
+
+fn set_read(CPU, (Int, Bool) -> Int) -> Unit
+
+fn set_write(CPU, (Int, Int, Bool) -> Unit) -> Unit
+
+fn step(CPU) -> Int
+
+fn to_hex(UInt8) -> String
+
+fn write(CPU, UInt16, UInt8, dummy~ : Bool = ..) -> Unit
+
+fn write16(CPU, UInt16, UInt16, dummy~ : Bool = ..) -> Unit
 
 // Types and methods
 type AddressHook
@@ -40,21 +103,6 @@ impl CPU {
   write(Self, UInt16, UInt8, dummy~ : Bool = ..) -> Unit
   write16(Self, UInt16, UInt16, dummy~ : Bool = ..) -> Unit
 }
-
-pub(all) enum Flag {
-  C
-  Z
-  I
-  D
-  B
-  U
-  V
-  N
-}
-impl Flag {
-  lor(Self, Self) -> Int
-}
-impl Eq for Flag
 
 type Flags
 impl Flags {
@@ -103,6 +151,7 @@ type Vector
 impl Eq for Vector
 
 // Type aliases
+pub typealias Flag = Int
 
 // Traits
 trait U16

--- a/lib/cpu/flags.mbt
+++ b/lib/cpu/flags.mbt
@@ -1,33 +1,29 @@
 ///|
-pub(all) enum Flag {
-  C // Carry Flag
-  Z // Zero Flag
-  I // Interrupt Disable Flag
-  D // Decimal Mode Flag
-  B // Break Command Flag
-  U // Unused Flag
-  V // Overflow Flag
-  N // Negative Flag
-} derive(Eq)
+pub typealias Flag = Int
 
 ///|
-pub fn Flag::lor(self : Flag, flag : Flag) -> Int {
-  self.bits() | flag.bits()
-}
+pub const C = 0b00000001 // 0x01 Carry Flag
 
 ///|
-fn bits(self : Flag) -> Int {
-  match self {
-    C => 0b00000001 // 0x01 Carry Flag
-    Z => 0b00000010 // 0x02 Zero Flag
-    I => 0b00000100 // 0x04 Interrupt Disable Flag
-    D => 0b00001000 // 0x08 Decimal Mode Flag
-    B => 0b00010000 // 0x10 Break Command Flag
-    U => 0b00100000 // 0x20 Unused Flag
-    V => 0b01000000 // 0x40 Overflow Flag
-    N => 0b10000000 // 0x80 Negative Flag
-  }
-}
+pub const Z = 0b00000010 // 0x02 Zero Flag
+
+///|
+pub const I = 0b00000100 // 0x04 Interrupt Disable Flag
+
+///|
+pub const D = 0b00001000 // 0x08 Decimal Mode Flag
+
+///|
+pub const B = 0b00010000 // 0x10 Break Command Flag
+
+///|
+pub const U = 0b00100000 // 0x20 Unused Flag
+
+///|
+pub const V = 0b01000000 // 0x40 Overflow Flag
+
+///|
+pub const N = 0b10000000 // 0x80 Negative Flag
 
 ///|
 struct Flags {
@@ -78,6 +74,7 @@ fn Flags::op_get(self : Flags, flag : Flag) -> Bool {
     U => self.u
     V => self.v
     N => self.n
+    _ => panic()
   }
 }
 
@@ -92,6 +89,7 @@ fn Flags::op_set(self : Flags, flag : Flag, value : Bool) -> Unit {
     U => self.u = value
     V => self.v = value
     N => self.n = value
+    _ => panic()
   }
 }
 

--- a/lib/cpu/types.mbt
+++ b/lib/cpu/types.mbt
@@ -19,38 +19,38 @@ fn u8(self : UInt16) -> UInt8 {
 }
 
 ///|
-fn op_add(self : UInt8, other : UInt8) -> UInt8 {
+impl Add for UInt8 with op_add(self : UInt8, other : UInt8) -> UInt8 {
   self._ + other._ // FIXME: Overflow
 }
 
 ///|
-fn op_sub(self : UInt8, other : UInt8) -> UInt8 {
+impl Sub for UInt8 with op_sub(self : UInt8, other : UInt8) -> UInt8 {
   self._ - other._ // FIXME: Underflow
 }
 
 ///|
-fn op_mul(self : UInt8, other : UInt8) -> UInt8 {
+impl Mul for UInt8 with op_mul(self : UInt8, other : UInt8) -> UInt8 {
   self._ * other._ // FIXME: Overflow
 }
 
 ///|
-fn op_div(self : UInt8, other : UInt8) -> UInt8 {
+impl Div for UInt8 with op_div(self : UInt8, other : UInt8) -> UInt8 {
   self._ / other._ // FIXME: Underflow
 }
 
 ///|
-fn op_mod(self : UInt8, other : UInt8) -> UInt8 {
+impl Mod for UInt8 with op_mod(self : UInt8, other : UInt8) -> UInt8 {
   self._ % other._
 }
 
 ///|
-fn op_shl(self : UInt8, bit : UInt8) -> UInt8 {
-  self._ << bit._
+impl Shl for UInt8 with op_shl(self : UInt8, bit : Int) -> UInt8 {
+  self._ << bit
 }
 
 ///|
-fn op_shr(self : UInt8, bit : UInt8) -> UInt8 {
-  self._ >> bit._
+impl Shr for UInt8 with op_shr(self : UInt8, bit : Int) -> UInt8 {
+  self._ >> bit
 }
 
 ///|
@@ -60,19 +60,19 @@ fn flip(self : UInt8, other : UInt8) -> UInt8 {
 
 // bitwise and
 ///|
-fn land(self : UInt8, other : UInt8) -> UInt8 {
+impl BitAnd for UInt8 with land(self : UInt8, other : UInt8) -> UInt8 {
   self._ & other._
 }
 
 // bitwise or
 ///|
-fn lor(self : UInt8, bit : UInt8) -> UInt8 {
+impl BitOr for UInt8 with lor(self : UInt8, bit : UInt8) -> UInt8 {
   self._ | bit._
 }
 
 // bitwise xor
 ///|
-fn lxor(self : UInt8, bit : UInt8) -> UInt8 {
+impl BitXOr for UInt8 with lxor(self : UInt8, bit : UInt8) -> UInt8 {
   self._ ^ bit._
 }
 
@@ -83,12 +83,12 @@ pub fn bit(self : UInt8, bit : UInt8) -> Bool {
   //   println("UInt8::bit out of bounds")
   //   abort("out of bounds")
   // }
-  ((self >> bit) & 1) == 1
+  ((self >> bit._) & 1) == 1
 }
 
 ///|
 fn bitn(self : UInt8, bit : UInt8) -> UInt8 {
-  (self >> bit) & 1
+  (self >> bit._) & 1
 }
 
 ///|
@@ -171,50 +171,50 @@ fn u16(self : UInt8) -> UInt16 {
 }
 
 ///|
-fn UInt16::op_add(self : UInt16, other : UInt16) -> UInt16 {
+impl Add for UInt16 with op_add(self : UInt16, other : UInt16) -> UInt16 {
   self._ + other._ |> u16 // handle overflow
 }
 
 ///|
-fn UInt16::op_sub(self : UInt16, other : UInt16) -> UInt16 {
+impl Sub for UInt16 with op_sub(self : UInt16, other : UInt16) -> UInt16 {
   self._ - other._ |> u16 // handle underflow
 }
 
 ///|
-fn UInt16::op_mul(self : UInt16, other : UInt16) -> UInt16 {
+impl Mul for UInt16 with op_mul(self : UInt16, other : UInt16) -> UInt16 {
   self._ * other._ |> u16 // handle overflow
 }
 
 ///|
-fn UInt16::op_div(self : UInt16, other : UInt16) -> UInt16 {
+impl Div for UInt16 with op_div(self : UInt16, other : UInt16) -> UInt16 {
   self._ / other._ |> u16 // handle underflow
 }
 
 ///|
-fn UInt16::op_shl(self : UInt16, bit : UInt16) -> UInt16 {
-  self._ << bit._ |> u16
+impl Shl for UInt16 with op_shl(self : UInt16, bit : Int) -> UInt16 {
+  self._ << bit |> u16
 }
 
 ///|
-fn UInt16::op_shr(self : UInt16, bit : UInt16) -> UInt16 {
-  self._ >> bit._ |> u16
+impl Shr for UInt16 with op_shr(self : UInt16, bit : Int) -> UInt16 {
+  self._ >> bit |> u16
 }
 
 // bitwise and
 ///|
-fn UInt16::land(self : UInt16, other : UInt16) -> UInt16 {
+impl BitAnd for UInt16 with land(self : UInt16, other : UInt16) -> UInt16 {
   self._ & other._
 }
 
 // bitwise or
 ///|
-fn UInt16::lor(self : UInt16, bit : UInt16) -> UInt16 {
+impl BitOr for UInt16 with lor(self : UInt16, bit : UInt16) -> UInt16 {
   self._ | bit._
 }
 
 // bitwise xor
 ///|
-fn UInt16::lxor(self : UInt16, bit : UInt16) -> UInt16 {
+impl BitXOr for UInt16 with lxor(self : UInt16, bit : UInt16) -> UInt16 {
   self._ ^ bit._
 }
 

--- a/lib/lib.mbti
+++ b/lib/lib.mbti
@@ -1,13 +1,59 @@
-package trancee/wasmSID/lib
+package "trancee/wasmSID/lib"
 
-alias @trancee/wasmSID/lib/cpu as @cpu
+import(
+  "trancee/wasmSID/lib/cpu"
+)
 
 // Values
 let cia1_mem_start : Int
 
 let cia2_mem_start : Int
 
+fn emulate(C64) -> Output
+
+fn get_registers(C64) -> @cpu.Registers
+
+fn hook(Memory, Int, Int, (UInt16, Bool) -> UInt8, (UInt16, UInt8, Bool) -> Unit) -> Unit
+
+fn initC64(C64) -> Unit!
+
+fn initCPU(C64, baseaddress? : Int) -> Unit
+
+fn load(NES, FixedArray[Int], addr~ : Int = .., length~ : Int = ..) -> Unit
+
+fn op_set(C64, C64register, UInt8) -> Unit
+
+fn pc(NES) -> Int
+
+fn process(PSID) -> Unit!
+
+fn push(NES, @cpu.UInt8) -> Unit
+
+fn push16(NES, @cpu.UInt16) -> Unit
+
+fn read(C64, Int, dummy~ : Bool = ..) -> Int
+
+fn reset(C64) -> Unit!
+
+fn set_bank(C64, IOPort) -> Unit
+
+fn set_flags(NES, @cpu.UInt8) -> Unit
+
+fn step(NES) -> Int
+
+fn to_hex(UInt8) -> String
+
+fn to_string(Exception) -> String
+
 let vic_mem_start : Int
+
+fn videoStandard(PSID) -> VideoStandard
+
+fn write(C64, Int, Int, dummy~ : Bool = ..) -> Unit
+
+fn write_array(C64, C64register, Array[UInt8]) -> Unit
+
+fn write_word(C64, C64register, UInt16) -> Unit
 
 // Types and methods
 type ADSR
@@ -27,29 +73,29 @@ pub(all) struct C64 {
   vic : VIC
   model : FixedArray[Model]
   realSID : Bool
-  sampleRate : Int
-  highQuality : Bool
-  stereo : Bool
-  playbackSpeed : Int
-  paused : Bool
-  videoStandard : VideoStandard
-  cpuFrequency : CPUClock
-  sampleClockRatio : Int
-  selectedModel : Model
-  mainVolume : Double
-  attenuation : Int
+  mut sampleRate : Int
+  mut highQuality : Bool
+  mut stereo : Bool
+  mut playbackSpeed : Int
+  mut paused : Bool
+  mut videoStandard : VideoStandard
+  mut cpuFrequency : CPUClock
+  mut sampleClockRatio : Int
+  mut selectedModel : Model
+  mut mainVolume : Double
+  mut attenuation : Int
   timerSource : Int
-  frameCycles : Int
-  frameCycleCnt : Int
-  prevRasterLine : Int
-  sampleCycleCnt : Int
-  overSampleCycleCnt : Int
-  finished : Bool
-  returned : Bool
-  irq : Bool
-  nmi : Bool
-  prevNMI : Bool
-  debug : Bool
+  mut frameCycles : Int
+  mut frameCycleCnt : Int
+  mut prevRasterLine : Int
+  mut sampleCycleCnt : Int
+  mut overSampleCycleCnt : Int
+  mut finished : Bool
+  mut returned : Bool
+  mut irq : Bool
+  mut nmi : Bool
+  mut prevNMI : Bool
+  mut debug : Bool
 }
 impl C64 {
   clear_flags(Self) -> Unit
@@ -458,26 +504,26 @@ impl Default for Output
 pub(all) struct PSID {
   mem : Memory
   data : FixedArray[Int]
-  version : Version
-  realSID : Bool
-  digiMode : Bool
-  loadAddress : Int
-  initAddress : Int
-  playAddress : Int
-  endAddress : Int
-  title : String
-  author : String
-  info : String
-  songs : UInt16
-  defaultSong : UInt16
-  flags : Flags
-  startPage : UInt8
-  pageLength : UInt8
-  sid2Flags : SIDFlags
-  sid3Flags : SIDFlags
-  sid4Flags : SIDFlags
-  sid2Address : UInt8
-  sid3Address : UInt8
+  mut version : Version
+  mut realSID : Bool
+  mut digiMode : Bool
+  mut loadAddress : Int
+  mut initAddress : Int
+  mut playAddress : Int
+  mut endAddress : Int
+  mut title : String
+  mut author : String
+  mut info : String
+  mut songs : UInt16
+  mut defaultSong : UInt16
+  mut flags : Flags
+  mut startPage : UInt8
+  mut pageLength : UInt8
+  mut sid2Flags : SIDFlags
+  mut sid3Flags : SIDFlags
+  mut sid4Flags : SIDFlags
+  mut sid2Address : UInt8
+  mut sid3Address : UInt8
 }
 impl PSID {
   new(Memory, FixedArray[Int]) -> Self!

--- a/lib/psid_types.mbt
+++ b/lib/psid_types.mbt
@@ -165,13 +165,3 @@ fn Flags::from_int(value : UInt16, realSID : Bool) -> Flags! {
     ],
   }
 }
-
-///|
-fn Flags::op_shr(self : Flags, bits : Int) -> Int {
-  self >> bits
-}
-
-///|
-fn Flags::land(self : Flags, bits : Int) -> Int {
-  self & bits
-}

--- a/lib/types.mbt
+++ b/lib/types.mbt
@@ -100,38 +100,38 @@ fn u8(self : UInt16) -> UInt8 {
 }
 
 ///|
-fn op_add(self : UInt8, other : UInt8) -> UInt8 {
+impl Add for UInt8 with op_add(self : UInt8, other : UInt8) -> UInt8 {
   self._ + other._ // FIXME: Overflow
 }
 
 ///|
-fn op_sub(self : UInt8, other : UInt8) -> UInt8 {
+impl Sub for UInt8 with op_sub(self : UInt8, other : UInt8) -> UInt8 {
   self._ - other._ // FIXME: Underflow
 }
 
 ///|
-fn op_mul(self : UInt8, other : UInt8) -> UInt8 {
+impl Mul for UInt8 with op_mul(self : UInt8, other : UInt8) -> UInt8 {
   self._ * other._ // FIXME: Overflow
 }
 
 ///|
-fn op_div(self : UInt8, other : UInt8) -> UInt8 {
+impl Div for UInt8 with op_div(self : UInt8, other : UInt8) -> UInt8 {
   self._ / other._ // FIXME: Underflow
 }
 
 ///|
-fn op_mod(self : UInt8, other : UInt8) -> UInt8 {
+impl Mod for UInt8 with op_mod(self : UInt8, other : UInt8) -> UInt8 {
   self._ % other._
 }
 
 ///|
-fn op_shl(self : UInt8, bit : UInt8) -> UInt8 {
-  self._ << bit._
+impl Shl for UInt8 with op_shl(self : UInt8, bit : Int) -> UInt8 {
+  self._ << bit
 }
 
 ///|
-fn UInt8::op_shr(self : UInt8, bit : UInt8) -> UInt8 {
-  self._ >> bit._
+impl Shr for UInt8 with op_shr(self : UInt8, bit : Int) -> UInt8 {
+  self._ >> bit
 }
 
 ///|
@@ -141,24 +141,24 @@ fn UInt8::flip(self : UInt8, other : UInt8) -> UInt8 {
 
 // bitwise and
 ///|
-fn UInt8::land(self : UInt8, other : UInt8) -> UInt8 {
+impl BitAnd for UInt8 with land(self : UInt8, other : UInt8) -> UInt8 {
   self._ & other._
 }
 
 // bitwise or
 ///|
-fn UInt8::lor(self : UInt8, bit : UInt8) -> UInt8 {
+impl BitOr for UInt8 with lor(self : UInt8, bit : UInt8) -> UInt8 {
   self._ | bit._
 }
 
 // bitwise xor
 ///|
-fn lxor(self : UInt8, bit : UInt8) -> UInt8 {
+impl BitXOr for UInt8 with lxor(self : UInt8, bit : UInt8) -> UInt8 {
   self._ ^ bit._
 }
 
 ///|
-fn bit(self : UInt8, bit : UInt8) -> Bool {
+fn bit(self : UInt8, bit : Int) -> Bool {
   if bit >= 8 {
     println("UInt8::bit out of bounds")
     abort("out of bounds")
@@ -244,50 +244,50 @@ fn u16(self : UInt8) -> UInt16 {
 // }
 
 ///|
-fn UInt16::op_add(self : UInt16, other : UInt16) -> UInt16 {
+impl Add for UInt16 with op_add(self : UInt16, other : UInt16) -> UInt16 {
   self._ + other._ |> u16 // handle overflow
 }
 
 ///|
-fn UInt16::op_sub(self : UInt16, other : UInt16) -> UInt16 {
+impl Sub for UInt16 with op_sub(self : UInt16, other : UInt16) -> UInt16 {
   self._ - other._ |> u16 // handle underflow
 }
 
 ///|
-fn UInt16::op_mul(self : UInt16, other : UInt16) -> UInt16 {
+impl Mul for UInt16 with op_mul(self : UInt16, other : UInt16) -> UInt16 {
   self._ * other._ |> u16 // handle overflow
 }
 
 ///|
-fn UInt16::op_div(self : UInt16, other : UInt16) -> UInt16 {
+impl Div for UInt16 with op_div(self : UInt16, other : UInt16) -> UInt16 {
   self._ / other._ |> u16 // handle underflow
 }
 
 ///|
-fn UInt16::op_shl(self : UInt16, bit : UInt16) -> UInt16 {
-  self._ << bit._ |> u16
+impl Shl for UInt16 with op_shl(self : UInt16, bit : Int) -> UInt16 {
+  self._ << bit |> u16
 }
 
 ///|
-fn UInt16::op_shr(self : UInt16, bit : UInt16) -> UInt16 {
-  self._ >> bit._ |> u16
+impl Shr for UInt16 with op_shr(self : UInt16, bit : Int) -> UInt16 {
+  self._ >> bit |> u16
 }
 
 // bitwise and
 ///|
-fn UInt16::land(self : UInt16, other : UInt16) -> UInt16 {
+impl BitAnd for UInt16 with land(self : UInt16, other : UInt16) -> UInt16 {
   self._ & other._
 }
 
 // bitwise or
 ///|
-fn UInt16::lor(self : UInt16, bit : UInt16) -> UInt16 {
+impl BitOr for UInt16 with lor(self : UInt16, bit : UInt16) -> UInt16 {
   self._ | bit._
 }
 
 // bitwise xor
 ///|
-fn UInt16::lxor(self : UInt16, bit : UInt16) -> UInt16 {
+impl BitXOr for UInt16 with lxor(self : UInt16, bit : UInt16) -> UInt16 {
   self._ ^ bit._
 }
 

--- a/main/main.mbti
+++ b/main/main.mbti
@@ -1,4 +1,4 @@
-package trancee/wasmSID/main
+package "trancee/wasmSID/main"
 
 // Values
 fn nestest() -> Unit

--- a/testsuite/testsuite.mbti
+++ b/testsuite/testsuite.mbti
@@ -1,4 +1,4 @@
-package trancee/wasmSID/testsuite
+package "trancee/wasmSID/testsuite"
 
 // Values
 let _start : FixedArray[Int]


### PR DESCRIPTION
- semantic of operator overloading changed from method based to trait based
    - operators with non-standard types are not supported anymore
- update `.mbti` format